### PR TITLE
FIX: corrections suite aux scénarios de test

### DIFF
--- a/app/controllers/SinistresController.php
+++ b/app/controllers/SinistresController.php
@@ -66,7 +66,7 @@ class SinistresController extends BaseController {
           Input::has('rapport') &&
           Input::has('categorie_id'))){
 
-        return $this->afficherErreur("Données de sinistre invalide pour insertion.");
+        return $this->afficherErreurWithInput("Données de sinistre invalide pour insertion.");
       }
 
       if (!Auth::check()) {
@@ -136,7 +136,7 @@ class SinistresController extends BaseController {
         } catch (Exception $w) {
           $message = $message . 'De plus, une erreure est survenue lors de la gestion d\'erreur: ' . $w->getMessage();
         }
-        return $this->afficherErreur('Le sinistre n\'a pu être reporté: </br>' . $message);
+        return $this->afficherErreurWithInput('Le sinistre n\'a pu être reporté: </br>' . $message);
       }
     }
 

--- a/public/js/geo.js
+++ b/public/js/geo.js
@@ -16,22 +16,15 @@
 
   function msieversion() {
     var msie = window.navigator.userAgent.indexOf("MSIE ");
-
     if (msie > 0 || !!navigator.userAgent.match(/Trident.*rv\:11\./))
         return true;
-
     return false;
   }
 
-  if (cmdFichiers.createShadowRoot != null) {
+  if (cmdFichiers.createShadowRoot != null && !msieversion()) {
     styliserBoutonFichier();
-  } else {
-    if (!msieversion()){
-      cmdFichiers.className = cmdFichiers.className + ' custom-file-input';
-    } else {
-      // Style spécial pour IE?
-    }
   }
+  
   cmdFichiers.onchange = function( event ) {
     lblNbFichiers.innerHTML = this.files.length + ' fichiers' ;
   };


### PR DESCRIPTION
Il n'y a plus de perte de données du formulaire d'ajout de sinistre si données invalides.
On peut ajouter un sinistre sans fichier.
Insertion HTML impossible.